### PR TITLE
feat(theme): Add custom theme support with dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ For more information about PrimeNG theming, visit the [PrimeNG Theming Documenta
 
 ## UAF Components Library
 
-This project includes a reusable UI components library called `@amarextraholding/uaf-components` that can be installed separately in other Angular projects.
+This project includes a reusable UI components library called `@amarhbaneen/uaf-components` that can be installed separately in other Angular projects.
 
 ### Installing from NPM
 
 To install the UAF Components library from NPM, run:
 
 ```bash
-npm install @amarextraholding/uaf-components
+npm install @amarhbaneen/uaf-components
 ```
 
 ### Required Peer Dependencies
@@ -197,7 +197,7 @@ npm install primeng primeicons primeflex @primeng/themes
 Import the UafComponentsModule in your application module:
 
 ```typescript
-import { UafComponentsModule } from '@amarextraholding/uaf-components';
+import { UafComponentsModule } from '@amarhbaneen/uaf-components';
 
 @NgModule({
   imports: [
@@ -209,7 +209,18 @@ import { UafComponentsModule } from '@amarextraholding/uaf-components';
 export class AppModule { }
 ```
 
+### Using the Theme
+
+To use the UAF theme in your application:
+
+```scss
+// In your styles.scss file
+@import '@amarhbaneen/uaf-components/src/lib/themes/index';
+```
+
 For more detailed documentation about the components library, see the [UAF Components Documentation](docs/uaf-components-documentation.md).
+
+For information about publishing updates to the library, see the [NPM Publishing Guide](docs/npm-publishing-guide.md).
 
 ## Documentation
 

--- a/docs/npm-publishing-guide.md
+++ b/docs/npm-publishing-guide.md
@@ -1,0 +1,184 @@
+# Publishing the UAF Components Library to NPM
+
+This guide explains how to publish the UAF Components library to NPM so it can be used in other Angular applications.
+
+## Prerequisites
+
+1. An NPM account (create one at [npmjs.com](https://npmjs.com) if you don't have one)
+2. Access to the @amarhbaneen organization on NPM (or change the package name if you don't have access)
+3. Node.js and npm installed on your machine
+
+## Before Publishing
+
+1. Update the repository URLs in both package.json files:
+   - Main package.json in the project root
+   - Library package.json in projects/uaf-components/package.json
+
+   Replace the placeholder URLs:
+   ```json
+   "repository": {
+     "type": "git",
+     "url": "https://github.com/yourusername/uaf-components.git"
+   },
+   "homepage": "https://github.com/yourusername/uaf-components",
+   "bugs": {
+     "url": "https://github.com/yourusername/uaf-components/issues"
+   }
+   ```
+   with your actual repository information.
+
+2. Make sure you're logged in to NPM:
+   ```
+   npm login
+   ```
+
+3. Update the version number in both package.json files if you're publishing an update:
+   - Main package.json in the project root
+   - Library package.json in projects/uaf-components/package.json
+
+   Follow semantic versioning (SemVer) principles:
+   - **MAJOR version** (x.0.0): Increment when making incompatible API changes
+   - **MINOR version** (0.x.0): Increment when adding functionality in a backward compatible manner
+   - **PATCH version** (0.0.x): Increment when making backward compatible bug fixes
+
+   For example, to update from version 1.1.2 to 1.1.3 (patch update):
+   ```json
+   "version": "1.1.3"
+   ```
+
+## Publishing Process
+
+The project is already configured with the necessary scripts for building and publishing. Follow these steps in order:
+
+1. **Make your changes to the library code**:
+   - Update components, services, or themes as needed
+   - Test your changes thoroughly
+   - Update documentation if necessary
+
+2. **Update version numbers**:
+   - Update the version in both package.json files (root and projects/uaf-components/package.json)
+   - Make sure both files have the same version number
+   - Commit your changes to version control
+
+3. **Build the library**:
+   ```
+   npm run build:lib
+   ```
+   This command builds the library and places the output in the dist/uaf-components directory.
+
+4. **Verify the build**:
+   - Check that all files were generated correctly in the dist/uaf-components directory
+   - Ensure theme files are included in the build
+
+5. **Publish the library to NPM**:
+   ```
+   npm run publish:lib
+   ```
+   This will publish the library to NPM with public access.
+
+6. **Verify the publication**:
+   - Check that the package is available on NPM: https://www.npmjs.com/package/@amarhbaneen/uaf-components
+   - Verify that the correct version is published
+
+## Using the Published Library
+
+Once published, you can use the library in other Angular applications by installing it:
+
+```
+npm install @amarhbaneen/uaf-components
+```
+
+### Importing Components
+
+Import the components in your Angular modules:
+
+```typescript
+import { UafComponentsModule } from '@amarhbaneen/uaf-components';
+
+@NgModule({
+  imports: [
+    UafComponentsModule
+  ]
+})
+export class AppModule { }
+```
+
+### Using the Theme
+
+The library includes a custom theme for PrimeNG components. To use the theme in your application:
+
+1. Import the theme in your application's main styles file (e.g., `styles.scss`):
+   ```scss
+   @import "@amarhbaneen/uaf-components/src/lib/themes/index";
+   ```
+
+2. Optional: To enable dark mode, add the `dark` class to your body element:
+   ```html
+   <body class="dark">
+     <!-- Your app content here -->
+   </body>
+   ```
+
+For more detailed information about the theme, see the [Theme Documentation](./theme-documentation.md).
+
+## Troubleshooting
+
+### Common Publishing Issues
+
+- **Access Denied Error**:
+  ```
+  npm ERR! code E403
+  npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/@amarhbaneen%2fuaf-components
+  npm ERR! 403 In most cases, you or one of your dependencies are requesting
+  npm ERR! 403 a package version that is forbidden by your security policy.
+  ```
+  **Solution**:
+  - Make sure you're logged in to NPM with the correct account: `npm login`
+  - Ensure you have access to the @amarhbaneen organization on NPM
+  - If you don't have access, either:
+    - Get added to the organization on NPM
+    - Change the package name to something you have access to
+
+- **Version Already Exists Error**:
+  ```
+  npm ERR! code E403
+  npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/@amarhbaneen%2fuaf-components - You cannot publish over the previously published versions
+  ```
+  **Solution**:
+  - Update the version number in both package.json files (root and projects/uaf-components/package.json)
+  - Make sure both files have the same version number
+
+- **Missing Files in Published Package**:
+  **Solution**:
+  - Check the ng-package.json file to ensure all necessary files are included in the assets array
+  - Rebuild the library and verify the contents of the dist folder before publishing
+
+- **Theme Import Error in Consuming Application**:
+  ```
+  Could not resolve "@amarhbaneen/uaf-components/src/lib/themes/index.scss"
+  ```
+  **Solution**:
+  - Make sure the theme files are properly exported in the package.json file:
+    ```json
+    "exports": {
+      "./src/lib/themes/index.scss": "./src/lib/themes/index.scss"
+    }
+    ```
+  - Verify that the theme files are included in the assets array in ng-package.json
+
+### After Publishing
+
+- **Verify Package Contents**:
+  You can check what files were published in your package using:
+  ```
+  npm view @amarhbaneen/uaf-components dist.tarball
+  ```
+  Then download and extract the tarball to inspect its contents.
+
+- **Testing the Published Package**:
+  Create a new Angular project and install your package to verify it works as expected:
+  ```
+  ng new test-app
+  cd test-app
+  npm install @amarhbaneen/uaf-components
+  ```

--- a/docs/theme-documentation.md
+++ b/docs/theme-documentation.md
@@ -1,54 +1,71 @@
-# Theme Documentation: eg-factory
+# UAF Components Theme Documentation
 
 ## Overview
 
-The `eg-factory` theme is a custom PrimeNG theme created specifically for this application. It provides consistent styling across all PrimeNG UI components while adhering to the application's design system.
+The UAF Components library includes a custom theme for PrimeNG components. This theme provides consistent styling across all PrimeNG UI components while adhering to the UAF design system.
 
 ## Theme Structure
 
 The theme is organized as follows:
 
-- **Base Tokens**: Defined in `base.ts`, these tokens establish the foundation of the theme including colors, typography, and spacing.
-- **Component Tokens**: Each PrimeNG component has its own theme file (e.g., `accordion.ts`, `button.ts`) that defines component-specific styling.
-- **Theme Preset**: All component themes are combined in `index.ts` to create a complete theme preset.
+- **Main Theme File**: `uaf-theme.scss` contains all the styling for PrimeNG components, including dark mode support.
+- **Index File**: `index.scss` serves as the entry point that imports the main theme file.
 
-## Design Token System
+## Features
 
-The theme uses PrimeNG's design token system, which allows for:
+The UAF theme includes:
 
-1. **Consistent Styling**: Design tokens ensure visual consistency across components.
-2. **Maintainability**: Changes to base tokens automatically propagate to all components.
-3. **Theme Variants**: Support for both light and dark modes.
+1. **PrimeNG Component Styling**: Custom styles for PrimeNG components like buttons, cards, and input fields.
+2. **Dark Mode Support**: Comprehensive dark mode styling that can be activated by adding the `.dark` class to the body element.
+3. **Custom Typography**: Uses "Varela Round" as the default font family.
 
 ## Dark Mode
 
-Dark mode is supported through the `.dark` selector. When this class is applied to a container element, all components within that container will switch to their dark mode styling.
+Dark mode is supported through the `.dark` selector. When this class is applied to the body element, all components will switch to their dark mode styling:
+
+```html
+<body class="dark">
+  <!-- Your app content here -->
+</body>
+```
+
+## Using the Theme in Your Application
+
+To use the UAF theme in your application:
+
+1. **Install the Library**:
+   ```
+   npm install @amarhbaneen/uaf-components
+   ```
+
+2. **Import the Theme**:
+   Add the following import to your application's main styles file (e.g., `styles.scss`):
+   ```scss
+   @import "@amarhbaneen/uaf-components/src/lib/themes/index";
+   ```
+
+3. **Optional: Enable Dark Mode**:
+   To enable dark mode, add the `dark` class to your body element:
+   ```html
+   <body class="dark">
+     <!-- Your app content here -->
+   </body>
+   ```
 
 ## Customizing the Theme
 
-To modify the theme:
+You can customize the theme by overriding the styles in your application's styles file after importing the UAF theme:
 
-1. **Base Tokens**: Update values in `base.ts` to make global changes.
-2. **Component-Specific Styling**: Modify individual component theme files.
-3. **Adding New Components**: Create a new theme file for the component and add it to `index.ts`.
+```scss
+@import "@amarhbaneen/uaf-components/src/lib/themes/index";
 
-## Implementation Example
+// Your custom styles here
+body {
+  font-family: "Your Custom Font", sans-serif;
+}
 
-Here's an example of how a component theme is defined (from `accordion.ts`):
-
-```typescript
-export default {
-  root: {
-    transitionDuration: "{transition.duration}"
-  },
-  panel: {
-    borderWidth: "0 0 1px 0",
-    borderColor: "{content.border.color}"
-  },
-  // Additional properties...
-} satisfies AccordionDesignTokens;
+// Override dark mode styles
+body.dark {
+  background-color: #333333;
+}
 ```
-
-## Usage
-
-The theme is automatically applied to all PrimeNG components used in the application through the configuration in `app.config.ts`.

--- a/docs/uaf-components-documentation.md
+++ b/docs/uaf-components-documentation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The UAF Components Library (`@amarextraholding/uaf-components`) is a collection of reusable UI components built with Angular and PrimeNG. These components are designed to provide a consistent user interface for applications that require user authentication and factory management features.
+The UAF Components Library (`@amarhbaneen/uaf-components`) is a collection of reusable UI components built with Angular and PrimeNG. These components are designed to provide a consistent user interface for applications that require user authentication and factory management features.
 
 ## Installation
 
@@ -11,7 +11,7 @@ The UAF Components Library (`@amarextraholding/uaf-components`) is a collection 
 To install the UAF Components library from NPM, run:
 
 ```bash
-npm install @amarextraholding/uaf-components
+npm install @amarhbaneen/uaf-components
 ```
 
 ### Required Peer Dependencies
@@ -27,7 +27,7 @@ npm install primeng primeicons primeflex @primeng/themes
 Import the UafComponentsModule in your application module:
 
 ```typescript
-import { UafComponentsModule } from '@amarextraholding/uaf-components';
+import { UafComponentsModule } from '@amarhbaneen/uaf-components';
 
 @NgModule({
   imports: [
@@ -43,7 +43,7 @@ For standalone components, you can import the module in your component:
 
 ```typescript
 import { Component } from '@angular/core';
-import { UafComponentsModule } from '@amarextraholding/uaf-components';
+import { UafComponentsModule } from '@amarhbaneen/uaf-components';
 
 @Component({
   selector: 'app-my-component',
@@ -61,126 +61,133 @@ export class MyComponent { }
 
 The library includes the following components:
 
-### Authentication Components
+### Login Component
 
-- **UafLoginComponent**: A login form component with validation and error handling
-- **UafRegisterComponent**: A registration form component with validation
-- **UafForgotPasswordComponent**: A form for password recovery
+A login form component with validation and error handling.
 
-### UI Components
+### Navbar Component
 
-- **UafButtonComponent**: Custom styled buttons with various states
-- **UafCardComponent**: Container component for content with consistent styling
-- **UafDialogComponent**: Modal dialog component for displaying information or forms
-- **UafTableComponent**: Data table component with sorting, filtering, and pagination
+Navigation bar component for application header with theme toggle and logout functionality.
 
-### Navigation Components
+### Dashboard Component
 
-- **UafNavbarComponent**: Navigation bar component for application header
-- **UafSidebarComponent**: Collapsible sidebar for application navigation
-- **UafBreadcrumbComponent**: Breadcrumb navigation component
+Main dashboard component that serves as a container for application content.
+
+### Settings Component
+
+Component for managing application settings.
 
 ## Component Usage Examples
 
 ### Login Component
 
-```typescript
+```html
 <uaf-login 
-  [loading]="isLoading"
   (loginSubmit)="onLoginSubmit($event)">
 </uaf-login>
 ```
 
-### Button Component
+With event handling in your component:
 
 ```typescript
-<uaf-button 
-  label="Submit" 
-  [loading]="isSubmitting"
-  (onClick)="handleSubmit()">
-</uaf-button>
+onLoginSubmit(credentials: { username: string, password: string }) {
+  // Handle login logic here
+}
 ```
 
-### Table Component
+### Navbar Component
 
-```typescript
-<uaf-table 
-  [data]="users" 
-  [columns]="columns"
-  [paginator]="true"
-  [rows]="10">
-</uaf-table>
+```html
+<uaf-navbar
+  (settingsClick)="onSettingsClick()"
+  (logoutClick)="onLogoutClick()">
+</uaf-navbar>
+```
+
+### Dashboard Component
+
+```html
+<uaf-dashboard
+  (settingsClick)="onSettingsClick()"
+  (logoutClick)="onLogoutClick()">
+</uaf-dashboard>
+```
+
+### Settings Component
+
+```html
+<uaf-settings
+  (settingsClick)="onSettingsClick()"
+  (logoutClick)="onLogoutClick()">
+</uaf-settings>
 ```
 
 ## Theming
 
-The UAF Components library uses PrimeNG's theming system and includes a custom theme called "eg-factory". This theme provides consistent styling across all components.
+The UAF Components library includes a built-in theme that provides styling for all components, including dark mode support.
 
-To use the custom theme, import it in your application's styles:
+To use the theme, import it in your application's styles.scss file:
 
 ```scss
 // In your styles.scss file
-@import '@amarextraholding/uaf-components/themes/eg-factory/theme.scss';
+@import '@amarhbaneen/uaf-components/src/lib/themes/index';
 ```
 
-## Services
+The theme includes:
+- Basic styling for all components
+- Dark mode support (activated by adding the 'dark' class to the body element)
+- PrimeNG component styling
+- PrimeIcons and PrimeFlex CSS
 
-The library includes several services that can be injected into your components:
-
-### UafAuthService
-
-Provides authentication-related functionality:
+To toggle between light and dark mode, you can use the following code:
 
 ```typescript
-import { UafAuthService } from '@amarextraholding/uaf-components';
-
-constructor(private authService: UafAuthService) { }
-
-login(username: string, password: string) {
-  this.authService.login(username, password).subscribe(
-    response => {
-      // Handle successful login
-    },
-    error => {
-      // Handle error
-    }
-  );
-}
+// Toggle dark mode
+const isDarkMode = document.body.classList.contains('dark');
+document.body.classList.toggle('dark', !isDarkMode);
+localStorage.setItem('theme', !isDarkMode ? 'dark' : 'light');
 ```
 
-### UafNotificationService
+For more detailed information about the theme, see the [Theme Documentation](./theme-documentation.md).
 
-Provides methods for displaying notifications:
+## Core Service
+
+The library includes a core service:
+
+### UafComponentsService
+
+Basic service provided by the library:
 
 ```typescript
-import { UafNotificationService } from '@amarextraholding/uaf-components';
+import { UafComponentsService } from '@amarhbaneen/uaf-components';
 
-constructor(private notificationService: UafNotificationService) { }
+constructor(private uafService: UafComponentsService) { }
 
-showSuccess() {
-  this.notificationService.showSuccess('Operation completed successfully');
-}
-
-showError() {
-  this.notificationService.showError('An error occurred');
-}
+// Use the service methods as needed
 ```
 
-## Directives
+## Updating the Library
 
-The library includes several directives that can be used in your templates:
+When a new version of the library is released, you can update it using npm:
 
-### UafTooltipDirective
-
-```typescript
-<button uafTooltip="Click to submit">Submit</button>
+```bash
+npm update @amarhbaneen/uaf-components
 ```
 
-### UafHighlightDirective
+Or to install a specific version:
 
-```typescript
-<div uafHighlight>This text will be highlighted</div>
+```bash
+npm install @amarhbaneen/uaf-components@x.y.z
 ```
+
+After updating, make sure to check the changelog for any breaking changes or new features.
+
+## Additional Resources
+
+- [Angular Documentation](https://angular.dev/)
+- [PrimeNG Documentation](https://primeng.org/)
+- [PrimeFlex Documentation](https://primeflex.org/)
+- [PrimeIcons Documentation](https://primeng.org/icons)
 
 ## Contribution
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "uaf-components",
+  "name": "@amarextraholding/uaf-components",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "uaf-components",
+      "name": "@amarextraholding/uaf-components",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amarextraholding/uaf-components",
-  "version": "1.0.0",
+  "name": "@amarhbaneen/uaf-components",
+  "version": "1.1.2",
   "description": "User Authentication Factory UI Components Library with PrimeNG",
   "keywords": [
     "angular",
@@ -14,11 +14,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yourusername/uaf-components.git"
+    "url": "https://github.com/amarhbaneen/uaf-App-port"
   },
-  "homepage": "https://github.com/yourusername/uaf-components",
+  "homepage": "https://github.com/amarhbaneen/uaf-App-port",
   "bugs": {
-    "url": "https://github.com/yourusername/uaf-components/issues"
+    "url": "https://github.com/amarhbaneen/uaf-App-port/issues"
   },
   "scripts": {
     "ng": "ng",

--- a/projects/uaf-components/README.md
+++ b/projects/uaf-components/README.md
@@ -9,7 +9,7 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 To install the UafComponents library from NPM, run:
 
 ```bash
-npm install @amarextraholding/uaf-components
+npm install @amarhbaneen/uaf-components
 ```
 
 ### Peer Dependencies
@@ -25,7 +25,7 @@ npm install primeng primeicons primeflex @primeng/themes
 Import the UafComponentsModule in your application module:
 
 ```typescript
-import { UafComponentsModule } from '@amarextraholding/uaf-components';
+import { UafComponentsModule } from '@amarhbaneen/uaf-components';
 
 @NgModule({
   imports: [
@@ -35,6 +35,77 @@ import { UafComponentsModule } from '@amarextraholding/uaf-components';
   // ...
 })
 export class AppModule { }
+```
+
+### Theme Usage
+
+The library includes a built-in theme that provides styling for all components, including dark mode support. To use the theme, import it in your application's styles.scss file:
+
+```scss
+// In your styles.scss file
+@import '@amarhbaneen/uaf-components/src/lib/themes/index';
+```
+
+The theme includes:
+- Basic styling for all components
+- Dark mode support (activated by adding the 'dark' class to the body element)
+- PrimeNG component styling
+- PrimeIcons and PrimeFlex CSS
+
+To toggle between light and dark mode, you can use the following code:
+
+```typescript
+// Toggle dark mode
+const isDarkMode = document.body.classList.contains('dark');
+document.body.classList.toggle('dark', !isDarkMode);
+localStorage.setItem('theme', !isDarkMode ? 'dark' : 'light');
+```
+
+### Available Components
+
+The library includes the following components:
+
+#### Login Component
+
+```html
+<uaf-login 
+  (loginSubmit)="onLoginSubmit($event)">
+</uaf-login>
+```
+
+With event handling in your component:
+
+```typescript
+onLoginSubmit(credentials: { username: string, password: string }) {
+  // Handle login logic here
+}
+```
+
+#### Navbar Component
+
+```html
+<uaf-navbar
+  (settingsClick)="onSettingsClick()"
+  (logoutClick)="onLogoutClick()">
+</uaf-navbar>
+```
+
+#### Dashboard Component
+
+```html
+<uaf-dashboard
+  (settingsClick)="onSettingsClick()"
+  (logoutClick)="onLogoutClick()">
+</uaf-dashboard>
+```
+
+#### Settings Component
+
+```html
+<uaf-settings
+  (settingsClick)="onSettingsClick()"
+  (logoutClick)="onLogoutClick()">
+</uaf-settings>
 ```
 
 ## Code scaffolding

--- a/projects/uaf-components/ng-package.json
+++ b/projects/uaf-components/ng-package.json
@@ -3,5 +3,8 @@
   "dest": "../../dist/uaf-components",
   "lib": {
     "entryFile": "src/public-api.ts"
-  }
+  },
+  "assets": [
+    "./src/lib/themes/**/*.scss"
+  ]
 }

--- a/projects/uaf-components/package.json
+++ b/projects/uaf-components/package.json
@@ -1,12 +1,38 @@
 {
-  "name": "@amarextraholding/uaf-components",
-  "version": "1.0.0",
+  "name": "@amarhbaneen/uaf-components",
+  "version": "1.1.2",
+  "description": "User Authentication Factory UI Components Library with PrimeNG",
+  "keywords": [
+    "angular",
+    "primeng",
+    "ui",
+    "components",
+    "authentication",
+    "factory"
+  ],
+  "author": "UAF Team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/amarhbaneen/uaf-App-port"
+  },
+  "homepage": "https://github.com/amarhbaneen/uaf-App-port",
+  "bugs": {
+    "url": "https://github.com/amarhbaneen/uaf-App-port/issues"
+  },
   "peerDependencies": {
     "@angular/common": "^19.2.0",
-    "@angular/core": "^19.2.0"
+    "@angular/core": "^19.2.0",
+    "primeng": "^19.1.3",
+    "@primeng/themes": "^19.1.3",
+    "primeflex": "^4.0.0",
+    "primeicons": "^7.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    "./src/lib/themes/index.scss": "./src/lib/themes/index.scss"
+  }
 }

--- a/projects/uaf-components/src/lib/themes/index.scss
+++ b/projects/uaf-components/src/lib/themes/index.scss
@@ -1,0 +1,1 @@
+@import './uaf-theme.scss';

--- a/projects/uaf-components/src/lib/themes/uaf-theme.scss
+++ b/projects/uaf-components/src/lib/themes/uaf-theme.scss
@@ -1,4 +1,4 @@
-/* You can add global styles to this file, and also import other style files */
+/* UAF Components Theme */
 @import "primeicons/primeicons.css";
 @import "primeflex/primeflex.css";
 

--- a/projects/uaf-components/src/lib/uaf-components.module.ts
+++ b/projects/uaf-components/src/lib/uaf-components.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { UafComponentsComponent } from './uaf-components.component';
+import { UafLoginComponent } from './components/login/login.component';
+import { UafNavbarComponent } from './components/navbar/navbar.component';
+import { UafDashboardComponent } from './components/dashboard/dashboard.component';
+import { UafSettingsComponent } from './components/settings/settings.component';
+
+@NgModule({
+  imports: [
+    UafComponentsComponent,
+    UafLoginComponent,
+    UafNavbarComponent,
+    UafDashboardComponent,
+    UafSettingsComponent
+  ],
+  exports: [
+    UafComponentsComponent,
+    UafLoginComponent,
+    UafNavbarComponent,
+    UafDashboardComponent,
+    UafSettingsComponent
+  ]
+})
+export class UafComponentsModule { }

--- a/projects/uaf-components/src/public-api.ts
+++ b/projects/uaf-components/src/public-api.ts
@@ -2,5 +2,16 @@
  * Public API Surface of uaf-components
  */
 
+// Original exports
 export * from './lib/uaf-components.service';
 export * from './lib/uaf-components.component';
+export * from './lib/uaf-components.module';
+
+// Component exports
+export * from './lib/components/login/login.component';
+export * from './lib/components/navbar/navbar.component';
+export * from './lib/components/dashboard/dashboard.component';
+export * from './lib/components/settings/settings.component';
+
+// Note: Theme files (SCSS) are included as assets in ng-package.json
+// and should be imported in the consuming application's styles.scss file


### PR DESCRIPTION
- Add UAF theme files with dark mode support
- Configure ng-package.json to include theme files as assets
- Update public-api.ts with theme export comments
- Create comprehensive theme documentation
- Add NPM publishing guide with theme integration instructions
- Update package.json with theme dependencies

This commit introduces a custom theme for the UAF Components library that provides consistent styling for all PrimeNG components with dark mode support. The theme can be imported in consuming applications and toggled between light and dark modes.